### PR TITLE
fix(task/new): handles case when creating the same Journal twice

### DIFF
--- a/Sources/JournalizeCore/NewTask.swift
+++ b/Sources/JournalizeCore/NewTask.swift
@@ -13,8 +13,14 @@ internal final class NewTask: Task, Executable {
 			throw Error.missingJournalName
 		}
 
-		try rootFolder.createFileIfNeeded(withName: "\(nameArgument).txt")
-		printer.output("🎊 \"\(nameArgument)\" journal sucessfully created!")
+		let fileNameWithExtension = "\(nameArgument).txt"
+
+		if rootFolder.containsFile(named: fileNameWithExtension) {
+			printer.output("👀 \"\(nameArgument)\" journal already exists! Use \"journalize switch \(nameArgument)\" to use existing journal.")
+		} else {
+			try rootFolder.createFileIfNeeded(withName: fileNameWithExtension)
+			printer.output("🎊 \"\(nameArgument)\" journal sucessfully created!")
+		}
 	}
 }
 

--- a/Tests/JournalizeTests/JournalizeTests.swift
+++ b/Tests/JournalizeTests/JournalizeTests.swift
@@ -22,10 +22,31 @@ class JournalizeTests: XCTestCase {
 		try testFolder.empty()
 
 		// Run the tool with the test arguments
-		let arguments = [testFolder.path, "new", "Work"]
+		let journalName = "Work"
+		let arguments = [testFolder.path, "new", journalName]
 		try Journalize.run(with: arguments, folderPath: testFolder.path)
 
 		// Assert that new Journal file was created
-		XCTAssertNotNil(try? testFolder.file(named: "Work.txt"), "Could not create new Journal file")
+		XCTAssertNotNil(try? testFolder.file(named: "\(journalName).txt"), "Could not create \"\(journalName)\" Journal file")
+	}
+
+	func testCreatingSameJournalTwice() throws {
+		// Empty the test folder to ensure a clean state
+		try testFolder.empty()
+
+		// Run the tool with the test arguments
+		let journalName = "Personal"
+		let arguments = [testFolder.path, "new", journalName]
+		try Journalize.run(with: arguments, folderPath: testFolder.path)
+
+		// Assert that new Journal file was created
+		XCTAssertNotNil(try? testFolder.file(named: "\(journalName).txt"), "Could not create \"\(journalName)\" Journal file")
+
+		// Run the tool again with the same test arguments
+		try Journalize.run(with: arguments, folderPath: testFolder.path)
+
+		// Assert that a duplicate Journal isn't created
+		let files = try FileManager().contentsOfDirectory(atPath: testFolder.path)
+		XCTAssertTrue(files.count == 1, "Files count should be 1")
 	}
 }

--- a/Tests/JournalizeTests/XCTestManifests.swift
+++ b/Tests/JournalizeTests/XCTestManifests.swift
@@ -3,6 +3,7 @@ import XCTest
 extension JournalizeTests {
     static let __allTests = [
         ("testCreatingNewJournal", testCreatingNewJournal),
+        ("testCreatingSameJournalTwice", testCreatingSameJournalTwice),
     ]
 }
 


### PR DESCRIPTION
Updates tests to check if the new command doesn't create new Journal file